### PR TITLE
Set @scalar-labs/scalardl-javascript-sdk-base to ^1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-node-client-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The Node.js client SDK for Scalar DL",
   "author": "Scalar, Inc.",
   "main": "scalardl-node-client-sdk.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git@github.com:scalar-labs/scalardl-node-client-sdk.git"
   },
   "dependencies": {
-    "@scalar-labs/scalardl-javascript-sdk-base": "^1.3.0",
+    "@scalar-labs/scalardl-javascript-sdk-base": "^1.3.1",
     "google-protobuf": "^3.6.1",
     "grpc": "^1.16.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@scalar-labs/scalardl-javascript-sdk-base@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@scalar-labs/scalardl-javascript-sdk-base/-/scalardl-javascript-sdk-base-1.3.0.tgz#b0f0db16d4db403806923f08f7c8e00d8fe1c3af"
-  integrity sha512-wnNvUD90ViDpkeMsR+EQLnduaV36zG3MnvvpPSEbK3eVo1IqqXea2n5Z8QYm2GTg44gi5iLR27dQLmLDiW+J5g==
+"@scalar-labs/scalardl-javascript-sdk-base@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@scalar-labs/scalardl-javascript-sdk-base/-/scalardl-javascript-sdk-base-1.3.1.tgz#3ff25096b98e1ee7d282b75ad2fc8537b1bfb8f5"
+  integrity sha512-WUSTM50QLx+pJASMt+i3xknIpUGXQAa0VPoxFDG49yvhDiNCrbca1E1y9CoYd3pwhb8IKEHwWqFG9vwd6foyWA==
   dependencies:
     jsrsasign "^8.0.12"
 


### PR DESCRIPTION
Due to a bugfix in scalardl-javascript-sdk-base 1.3.1, we set Scalar Web SDK to be based on >=1.3.1 and <2.0.0