### PR TITLE
CI : Use Github PAT to authenticate when cloning scalar-samples repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: checkout scalar-samples repository as it contains the script to spin up scalardl environment and easier for us to maintain the CI
           command: |
             git init
-            git pull https://${GHCR_USERNAME}:${GITHUB_PASSWORD}@github.com/scalar-labs/scalar-samples.git
+            git pull https://${GHCR_USERNAME}:${GHCR_PAT}@github.com/scalar-labs/scalar-samples.git
           working_directory: .circleci/
 
 


### PR DESCRIPTION
In Circle CI configuration, use Github PAT to authenticate when cloning scalar-samples repository instead of using the github password.