### PR TITLE
Avoid publishing benchmark/ to NPM registry

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ example/
 .circleci/
 .eslintrc.json
 test/
+benchmark/


### PR DESCRIPTION
This PR adds `benchmark/` to `.npmignore` to avoid publishing the benchmark folder to the NPM registry.