### PR TITLE
Prettify JavaScript files

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,6 +1,4 @@
-const {
-  ClientService,
-} = require('../');
+const {ClientService} = require('../');
 
 const path = require('path');
 
@@ -12,98 +10,95 @@ const path = require('path');
     'scalar.dl.client.cert_holder_id': `foo@${Date.now()}`,
     'scalar.dl.client.cert_version': 1,
     'scalar.dl.client.tls.enabled': false,
-    
-    'scalar.dl.client.private_key_pem': '-----BEGIN EC PRIVATE KEY-----\n' +
-        'MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49\n' +
-        'AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20\n' +
-        'XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==\n-----END EC PRIVATE KEY-----\n',
-    
-    'scalar.dl.client.cert_pem': '-----BEGIN CERTIFICATE-----\n' +
-        'MIICizCCAjKgAwIBAgIUMEUDTdWsQpftFkqs6bCd6U++4nEwCgYIKoZIzj0EAwIw\n' +
-        'bzELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzEf\n' +
-        'MB0GA1UEChMWU2FtcGxlIEludGVybWVkaWF0ZSBDQTEfMB0GA1UEAxMWU2FtcGxl\n' +
-        'IEludGVybWVkaWF0ZSBDQTAeFw0xODA5MTAwODA3MDBaFw0yMTA5MDkwODA3MDBa\n' +
-        'MEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJ\n' +
-        'bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n' +
-        'AAQEa6Gq6bKHsFU2pw0oBBCKkMaihSlRG97Z07rqlAKCO1J+7uUlXbRdhZ2uCjRj\n' +
-        'd5cSG8rSWxRE703Ses+JBZPgo4HVMIHSMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\n' +
-        'DDAKBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRDd2MS9Ndo68PJ\n' +
-        'y9K/RNY6syZW0zAfBgNVHSMEGDAWgBR+Y+v8yByDNp39G7trYrTfZ0UjJzAxBggr\n' +
-        'BgEFBQcBAQQlMCMwIQYIKwYBBQUHMAGGFWh0dHA6Ly9sb2NhbGhvc3Q6ODg4OTAq\n' +
-        'BgNVHR8EIzAhMB+gHaAbhhlodHRwOi8vbG9jYWxob3N0Ojg4ODgvY3JsMAoGCCqG\n' +
-        'SM49BAMCA0cAMEQCIC/Bo4oNU6yHFLJeme5ApxoNdyu3rWyiqWPxJmJAr9L0AiBl\n' +
-        'Gc/v+yh4dHIDhCrimajTQAYOG9n0kajULI70Gg7TNw==\n-----END CERTIFICATE-----\n',
-    
-    'scalar.dl.client.tls.ca_root_cert_pem': '-----BEGIN CERTIFICATE-----\n' +
-        'MIIE/jCCAuagAwIBAgIJAJO8tpVEEORLMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV\n' +
-        'BAMMCWxvY2FsaG9zdDAeFw0xOTAzMTMxMDUyMTFaFw0yMDAzMTIxMDUyMTFaMBQx\n' +
-        'EjAQBgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC\n' +
-        'ggIBAKFeFSrXRh5jA+OodMPw0XFO4sd4G9wYERlxgCjDmd9eC+loLpjGwRwwO7os\n' +
-        '/+rhW+Cg/NGhNn64xCmS/JtZf91SBD1QfQ4wk4094sAUIHsztaWtZTATl6aIy0BN\n' +
-        '21A0ueFgVQGehwO1FdRKtS7X+45YV2vMMK/UQ69VSCwY82olBRgWp45TXLUmWVgC\n' +
-        'UAJkE/V2Ch8WLyKpCggtaxYmn8YfzA1X20QDK1b2IW4YPDcPapQLtU6wqIjrXX1E\n' +
-        'w992GgfERm//I14QEyu+qIPafsniDGYxiR6HK8nqeR70QcGHt+Qql24xyjwWHEA/\n' +
-        '43pn3jjrNVRhiVAD8tkVyRmfWjIngksRHPwEh3jG34gshOi9xAaID+mx2AWhThsk\n' +
-        'XbuqSxHckPlvgWHugZmFOwKZAgU5/gpnWR7oHPOSYffhGwmc/+SK/SQ4UDeTFI2c\n' +
-        '40Xw22P8CWbIq4gKi66kSvuFbLSeKQIRMJd50hf7kw3SqnkqEaeRXy5jBovut7CU\n' +
-        'nwcgGPceYmWhKxhkg5urzk+CQZENf+9+pVvArOQemn9bMuaBPwtwXE42+fktQpQ2\n' +
-        'PG3k7ryVL5R0jhuVNXf9ioU2z1ONQ2IdsuFtCKnozfVBAhy9bPfm120rTV/UBOCD\n' +
-        'zcmfRnv081lG9BN/KtZBo7hfFH/ZD2542yVRvibRIIdPWIkTAgMBAAGjUzBRMB0G\n' +
-        'A1UdDgQWBBQ61fQAtAgd7sM/NDtIX4D8GSA/8DAfBgNVHSMEGDAWgBQ61fQAtAgd\n' +
-        '7sM/NDtIX4D8GSA/8DAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IC\n' +
-        'AQCaYh1bxlj9Impoq3rmFHl5/9Fb2o2H2Ne8VjTHb8eSoHuLwXdWzKnw6UhiCaN4\n' +
-        'EZgrsqq1L2Tc8Y+eqT4gz3uDLc5Cj29HHC/suZezIo3lgyZ/A6stYQXE5Gy8e+to\n' +
-        'Qhmf4u8RMZ8zt6i355un6mTJxJq7JxoVqpECf5tg6pMdOUzbcKLTmN6i50jH/PSO\n' +
-        'NQsJhiSJg3caNdWviob+UwEuUineMF/X08dB3gphZ7kmfDeRjmONALMXS1uvPwk2\n' +
-        '3s8S45LmxETx+tcJSvckKRC9JaQf6dgHfKAWHpkIqvLKyqy9Dmvg2RSJi3kI9oaj\n' +
-        'dm64zc6CAsqVaPvoMfWIN7JZq9jvzc8msGiilfhiYoc+M3jvnmM81FuGbAw7Utq4\n' +
-        'uuHtpCcpbxRMChD4WdlrPeBONyBKp+RRWTGfBY1GW5aGWVp/cbcpIc2RSgnZcrxb\n' +
-        '6ef2iTMtUjRd76JlkobTyvgo0GKdLgnr8c711I2YNp+TabKIKZOEvw2X+oGbfxBN\n' +
-        '1WvRB5YJo2rzwZj0fSvN9IwT9TGxSZIo5zcaQuwLEmDZBJShgXN5Ya71Vag1AP2i\n' +
-        'mOwUJRvfTVPWg+wtF2JQwaPpK0+Kb7oCq9tl3PUW40FRgqWV1Tgp6Co/U1W/1BU6\n' +
-        '02Vmic/M/HmRMwWuX1PyVOVr8Mjyj+OMF1JsmdR5eL5Mtg==\n' +
-        '-----END CERTIFICATE-----\n',
+
+    'scalar.dl.client.private_key_pem':
+      '-----BEGIN EC PRIVATE KEY-----\n' +
+      'MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49\n' +
+      'AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20\n' +
+      'XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==\n-----END EC PRIVATE KEY-----\n',
+
+    'scalar.dl.client.cert_pem':
+      '-----BEGIN CERTIFICATE-----\n' +
+      'MIICizCCAjKgAwIBAgIUMEUDTdWsQpftFkqs6bCd6U++4nEwCgYIKoZIzj0EAwIw\n' +
+      'bzELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzEf\n' +
+      'MB0GA1UEChMWU2FtcGxlIEludGVybWVkaWF0ZSBDQTEfMB0GA1UEAxMWU2FtcGxl\n' +
+      'IEludGVybWVkaWF0ZSBDQTAeFw0xODA5MTAwODA3MDBaFw0yMTA5MDkwODA3MDBa\n' +
+      'MEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJ\n' +
+      'bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n' +
+      'AAQEa6Gq6bKHsFU2pw0oBBCKkMaihSlRG97Z07rqlAKCO1J+7uUlXbRdhZ2uCjRj\n' +
+      'd5cSG8rSWxRE703Ses+JBZPgo4HVMIHSMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\n' +
+      'DDAKBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRDd2MS9Ndo68PJ\n' +
+      'y9K/RNY6syZW0zAfBgNVHSMEGDAWgBR+Y+v8yByDNp39G7trYrTfZ0UjJzAxBggr\n' +
+      'BgEFBQcBAQQlMCMwIQYIKwYBBQUHMAGGFWh0dHA6Ly9sb2NhbGhvc3Q6ODg4OTAq\n' +
+      'BgNVHR8EIzAhMB+gHaAbhhlodHRwOi8vbG9jYWxob3N0Ojg4ODgvY3JsMAoGCCqG\n' +
+      'SM49BAMCA0cAMEQCIC/Bo4oNU6yHFLJeme5ApxoNdyu3rWyiqWPxJmJAr9L0AiBl\n' +
+      'Gc/v+yh4dHIDhCrimajTQAYOG9n0kajULI70Gg7TNw==\n' +
+      '-----END CERTIFICATE-----\n',
+
+    'scalar.dl.client.tls.ca_root_cert_pem':
+      '-----BEGIN CERTIFICATE-----\n' +
+      'MIIE/jCCAuagAwIBAgIJAJO8tpVEEORLMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV\n' +
+      'BAMMCWxvY2FsaG9zdDAeFw0xOTAzMTMxMDUyMTFaFw0yMDAzMTIxMDUyMTFaMBQx\n' +
+      'EjAQBgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC\n' +
+      'ggIBAKFeFSrXRh5jA+OodMPw0XFO4sd4G9wYERlxgCjDmd9eC+loLpjGwRwwO7os\n' +
+      '/+rhW+Cg/NGhNn64xCmS/JtZf91SBD1QfQ4wk4094sAUIHsztaWtZTATl6aIy0BN\n' +
+      '21A0ueFgVQGehwO1FdRKtS7X+45YV2vMMK/UQ69VSCwY82olBRgWp45TXLUmWVgC\n' +
+      'UAJkE/V2Ch8WLyKpCggtaxYmn8YfzA1X20QDK1b2IW4YPDcPapQLtU6wqIjrXX1E\n' +
+      'w992GgfERm//I14QEyu+qIPafsniDGYxiR6HK8nqeR70QcGHt+Qql24xyjwWHEA/\n' +
+      '43pn3jjrNVRhiVAD8tkVyRmfWjIngksRHPwEh3jG34gshOi9xAaID+mx2AWhThsk\n' +
+      'XbuqSxHckPlvgWHugZmFOwKZAgU5/gpnWR7oHPOSYffhGwmc/+SK/SQ4UDeTFI2c\n' +
+      '40Xw22P8CWbIq4gKi66kSvuFbLSeKQIRMJd50hf7kw3SqnkqEaeRXy5jBovut7CU\n' +
+      'nwcgGPceYmWhKxhkg5urzk+CQZENf+9+pVvArOQemn9bMuaBPwtwXE42+fktQpQ2\n' +
+      'PG3k7ryVL5R0jhuVNXf9ioU2z1ONQ2IdsuFtCKnozfVBAhy9bPfm120rTV/UBOCD\n' +
+      'zcmfRnv081lG9BN/KtZBo7hfFH/ZD2542yVRvibRIIdPWIkTAgMBAAGjUzBRMB0G\n' +
+      'A1UdDgQWBBQ61fQAtAgd7sM/NDtIX4D8GSA/8DAfBgNVHSMEGDAWgBQ61fQAtAgd\n' +
+      '7sM/NDtIX4D8GSA/8DAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IC\n' +
+      'AQCaYh1bxlj9Impoq3rmFHl5/9Fb2o2H2Ne8VjTHb8eSoHuLwXdWzKnw6UhiCaN4\n' +
+      'EZgrsqq1L2Tc8Y+eqT4gz3uDLc5Cj29HHC/suZezIo3lgyZ/A6stYQXE5Gy8e+to\n' +
+      'Qhmf4u8RMZ8zt6i355un6mTJxJq7JxoVqpECf5tg6pMdOUzbcKLTmN6i50jH/PSO\n' +
+      'NQsJhiSJg3caNdWviob+UwEuUineMF/X08dB3gphZ7kmfDeRjmONALMXS1uvPwk2\n' +
+      '3s8S45LmxETx+tcJSvckKRC9JaQf6dgHfKAWHpkIqvLKyqy9Dmvg2RSJi3kI9oaj\n' +
+      'dm64zc6CAsqVaPvoMfWIN7JZq9jvzc8msGiilfhiYoc+M3jvnmM81FuGbAw7Utq4\n' +
+      'uuHtpCcpbxRMChD4WdlrPeBONyBKp+RRWTGfBY1GW5aGWVp/cbcpIc2RSgnZcrxb\n' +
+      '6ef2iTMtUjRd76JlkobTyvgo0GKdLgnr8c711I2YNp+TabKIKZOEvw2X+oGbfxBN\n' +
+      '1WvRB5YJo2rzwZj0fSvN9IwT9TGxSZIo5zcaQuwLEmDZBJShgXN5Ya71Vag1AP2i\n' +
+      'mOwUJRvfTVPWg+wtF2JQwaPpK0+Kb7oCq9tl3PUW40FRgqWV1Tgp6Co/U1W/1BU6\n' +
+      '02Vmic/M/HmRMwWuX1PyVOVr8Mjyj+OMF1JsmdR5eL5Mtg==\n' +
+      '-----END CERTIFICATE-----\n',
   };
   const clientService = new ClientService(properties);
-  
+
   try {
     console.log('Register certificate');
     await clientService.registerCertificate();
     console.log('certificate registered');
-    
+
     console.log('Register contract');
     const fs = require('fs');
     const buffer = fs.readFileSync(
-        path.join(
-            __dirname,
-            '..',
-            'test/StateUpdater.class',
-        )
+        path.join(__dirname, '..', 'test/StateUpdater.class'),
     );
     const contractId =
-        `${properties['scalar.dl.client.cert_holder_id']}_StateUpdater`;
+      `${properties['scalar.dl.client.cert_holder_id']}_StateUpdater`;
     await clientService.registerContract(
         contractId,
         'com.org1.contract.StateUpdater',
         buffer,
-        {'properties': ''},
+        {properties: ''},
     );
     console.log('Contract registered');
-    
+
     console.log('List registered contracts');
     r = await clientService.listContracts();
     console.log(r);
-    
+
     console.log('Execute contract');
-    r = await clientService.executeContract(
-        contractId,
-        {
-          asset_id: 'foo',
-          state: 1,
-        },
-    );
+    r = await clientService.executeContract(contractId, {
+      asset_id: 'foo',
+      state: 1,
+    });
     console.log(r);
-    
+
     console.log('Validate ledger');
     r = await clientService.validateLedger('foo', 0, 1);
     console.log(r);

--- a/example/serialized_request/web-service/node-server.js
+++ b/example/serialized_request/web-service/node-server.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const {
   ClientServiceWithBinary,
-  ClientError,
 } = require('@scalar-labs/scalardl-node-client-sdk');
 const cors = require('cors');
 const app = express();
@@ -9,9 +8,9 @@ const nodeServerPort = 3002;
 const bodyParser = require('body-parser');
 app.use(bodyParser.raw({type: 'application/octet-stream'}));
 app.use(cors());
-app.listen(nodeServerPort,
-    () => console.log(
-        `Web-server listening at http://localhost:${nodeServerPort}`));
+app.listen(nodeServerPort, () =>
+  console.log(`Web-server listening at http://localhost:${nodeServerPort}`),
+);
 
 // Node SDK configuration properties
 const binaryClientProperties = {
@@ -19,8 +18,7 @@ const binaryClientProperties = {
   'scalar.dl.client.server.port': 50051,
   'scalar.dl.client.server.privileged_port': 50052,
 };
-const binaryClientService = new ClientServiceWithBinary(
-    binaryClientProperties);
+const binaryClientService = new ClientServiceWithBinary(binaryClientProperties);
 
 app.post('/register-certificate', async (req, res) => {
   const serializedRequest = req.body;
@@ -59,6 +57,5 @@ app.post('/list-contracts', async (req, res) => {
  */
 function handleError(res, e) {
   console.error(e);
-  res.status(e.code)
-      .send({error: e.message});
+  res.status(e.code).send({error: e.message});
 }

--- a/signer.js
+++ b/signer.js
@@ -20,11 +20,15 @@ class EllipticSigner {
    */
   async sign(content) {
     try {
-      const base64 = this.pem.replace('-----BEGIN EC PRIVATE KEY-----', '').
-          replace('-----END EC PRIVATE KEY-----', '').
-          replace(/\n/g, '');
+      const base64 = this.pem
+          .replace('-----BEGIN EC PRIVATE KEY-----', '')
+          .replace('-----END EC PRIVATE KEY-----', '')
+          .replace(/\n/g, '');
       const {prvKeyHex} = jsrsasign.KEYUTIL.getKey(
-          jsrsasign.b64utohex(base64), null, 'pkcs5prv');
+          jsrsasign.b64utohex(base64),
+          null,
+          'pkcs5prv',
+      );
       const EC = elliptic.ec;
       const ecdsaCurve = elliptic.curves['p256'];
       const ecdsa = new EC(ecdsaCurve);

--- a/test/integration_test_auditor.js
+++ b/test/integration_test_auditor.js
@@ -1,6 +1,4 @@
-const {
-  ClientService,
-} = require('../scalardl-node-client-sdk');
+const {ClientService} = require('../scalardl-node-client-sdk');
 const fs = require('fs');
 const assert = require('assert');
 
@@ -22,59 +20,62 @@ const properties = {
   // Make the test idempotent.
   'scalar.dl.client.cert_holder_id': `foo@${Date.now()}`,
 
-  'scalar.dl.client.private_key_pem': '-----BEGIN EC PRIVATE KEY-----\n' +
-  'MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49\n' +
-  'AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20\n' +
-  'XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==\n-----END EC PRIVATE KEY-----\n',
+  'scalar.dl.client.private_key_pem':
+    '-----BEGIN EC PRIVATE KEY-----\n' +
+    'MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49\n' +
+    'AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20\n' +
+    'XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==\n-----END EC PRIVATE KEY-----\n',
 
-  'scalar.dl.client.cert_pem': '-----BEGIN CERTIFICATE-----\n' +
-  'MIICizCCAjKgAwIBAgIUMEUDTdWsQpftFkqs6bCd6U++4nEwCgYIKoZIzj0EAwIw\n' +
-  'bzELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzEf\n' +
-  'MB0GA1UEChMWU2FtcGxlIEludGVybWVkaWF0ZSBDQTEfMB0GA1UEAxMWU2FtcGxl\n' +
-  'IEludGVybWVkaWF0ZSBDQTAeFw0xODA5MTAwODA3MDBaFw0yMTA5MDkwODA3MDBa\n' +
-  'MEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJ\n' +
-  'bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n' +
-  'AAQEa6Gq6bKHsFU2pw0oBBCKkMaihSlRG97Z07rqlAKCO1J+7uUlXbRdhZ2uCjRj\n' +
-  'd5cSG8rSWxRE703Ses+JBZPgo4HVMIHSMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\n' +
-  'DDAKBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRDd2MS9Ndo68PJ\n' +
-  'y9K/RNY6syZW0zAfBgNVHSMEGDAWgBR+Y+v8yByDNp39G7trYrTfZ0UjJzAxBggr\n' +
-  'BgEFBQcBAQQlMCMwIQYIKwYBBQUHMAGGFWh0dHA6Ly9sb2NhbGhvc3Q6ODg4OTAq\n' +
-  'BgNVHR8EIzAhMB+gHaAbhhlodHRwOi8vbG9jYWxob3N0Ojg4ODgvY3JsMAoGCCqG\n' +
-  'SM49BAMCA0cAMEQCIC/Bo4oNU6yHFLJeme5ApxoNdyu3rWyiqWPxJmJAr9L0AiBl\n' +
-  'Gc/v+yh4dHIDhCrimajTQAYOG9n0kajULI70Gg7TNw==\n-----END CERTIFICATE-----\n',
+  'scalar.dl.client.cert_pem':
+    '-----BEGIN CERTIFICATE-----\n' +
+    'MIICizCCAjKgAwIBAgIUMEUDTdWsQpftFkqs6bCd6U++4nEwCgYIKoZIzj0EAwIw\n' +
+    'bzELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzEf\n' +
+    'MB0GA1UEChMWU2FtcGxlIEludGVybWVkaWF0ZSBDQTEfMB0GA1UEAxMWU2FtcGxl\n' +
+    'IEludGVybWVkaWF0ZSBDQTAeFw0xODA5MTAwODA3MDBaFw0yMTA5MDkwODA3MDBa\n' +
+    'MEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJ\n' +
+    'bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n' +
+    'AAQEa6Gq6bKHsFU2pw0oBBCKkMaihSlRG97Z07rqlAKCO1J+7uUlXbRdhZ2uCjRj\n' +
+    'd5cSG8rSWxRE703Ses+JBZPgo4HVMIHSMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\n' +
+    'DDAKBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRDd2MS9Ndo68PJ\n' +
+    'y9K/RNY6syZW0zAfBgNVHSMEGDAWgBR+Y+v8yByDNp39G7trYrTfZ0UjJzAxBggr\n' +
+    'BgEFBQcBAQQlMCMwIQYIKwYBBQUHMAGGFWh0dHA6Ly9sb2NhbGhvc3Q6ODg4OTAq\n' +
+    'BgNVHR8EIzAhMB+gHaAbhhlodHRwOi8vbG9jYWxob3N0Ojg4ODgvY3JsMAoGCCqG\n' +
+    'SM49BAMCA0cAMEQCIC/Bo4oNU6yHFLJeme5ApxoNdyu3rWyiqWPxJmJAr9L0AiBl\n' +
+    'Gc/v+yh4dHIDhCrimajTQAYOG9n0kajULI70Gg7TNw==\n-----END CERTIFICATE-----\n',
 
   'scalar.dl.client.cert_version': 1,
   'scalar.dl.client.tls.enabled': false,
 
-  'scalar.dl.client.tls.ca_root_cert_pem': '-----BEGIN CERTIFICATE-----\n' +
-  'MIIE/jCCAuagAwIBAgIJAJO8tpVEEORLMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV\n' +
-  'BAMMCWxvY2FsaG9zdDAeFw0xOTAzMTMxMDUyMTFaFw0yMDAzMTIxMDUyMTFaMBQx\n' +
-  'EjAQBgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC\n' +
-  'ggIBAKFeFSrXRh5jA+OodMPw0XFO4sd4G9wYERlxgCjDmd9eC+loLpjGwRwwO7os\n' +
-  '/+rhW+Cg/NGhNn64xCmS/JtZf91SBD1QfQ4wk4094sAUIHsztaWtZTATl6aIy0BN\n' +
-  '21A0ueFgVQGehwO1FdRKtS7X+45YV2vMMK/UQ69VSCwY82olBRgWp45TXLUmWVgC\n' +
-  'UAJkE/V2Ch8WLyKpCggtaxYmn8YfzA1X20QDK1b2IW4YPDcPapQLtU6wqIjrXX1E\n' +
-  'w992GgfERm//I14QEyu+qIPafsniDGYxiR6HK8nqeR70QcGHt+Qql24xyjwWHEA/\n' +
-  '43pn3jjrNVRhiVAD8tkVyRmfWjIngksRHPwEh3jG34gshOi9xAaID+mx2AWhThsk\n' +
-  'XbuqSxHckPlvgWHugZmFOwKZAgU5/gpnWR7oHPOSYffhGwmc/+SK/SQ4UDeTFI2c\n' +
-  '40Xw22P8CWbIq4gKi66kSvuFbLSeKQIRMJd50hf7kw3SqnkqEaeRXy5jBovut7CU\n' +
-  'nwcgGPceYmWhKxhkg5urzk+CQZENf+9+pVvArOQemn9bMuaBPwtwXE42+fktQpQ2\n' +
-  'PG3k7ryVL5R0jhuVNXf9ioU2z1ONQ2IdsuFtCKnozfVBAhy9bPfm120rTV/UBOCD\n' +
-  'zcmfRnv081lG9BN/KtZBo7hfFH/ZD2542yVRvibRIIdPWIkTAgMBAAGjUzBRMB0G\n' +
-  'A1UdDgQWBBQ61fQAtAgd7sM/NDtIX4D8GSA/8DAfBgNVHSMEGDAWgBQ61fQAtAgd\n' +
-  '7sM/NDtIX4D8GSA/8DAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IC\n' +
-  'AQCaYh1bxlj9Impoq3rmFHl5/9Fb2o2H2Ne8VjTHb8eSoHuLwXdWzKnw6UhiCaN4\n' +
-  'EZgrsqq1L2Tc8Y+eqT4gz3uDLc5Cj29HHC/suZezIo3lgyZ/A6stYQXE5Gy8e+to\n' +
-  'Qhmf4u8RMZ8zt6i355un6mTJxJq7JxoVqpECf5tg6pMdOUzbcKLTmN6i50jH/PSO\n' +
-  'NQsJhiSJg3caNdWviob+UwEuUineMF/X08dB3gphZ7kmfDeRjmONALMXS1uvPwk2\n' +
-  '3s8S45LmxETx+tcJSvckKRC9JaQf6dgHfKAWHpkIqvLKyqy9Dmvg2RSJi3kI9oaj\n' +
-  'dm64zc6CAsqVaPvoMfWIN7JZq9jvzc8msGiilfhiYoc+M3jvnmM81FuGbAw7Utq4\n' +
-  'uuHtpCcpbxRMChD4WdlrPeBONyBKp+RRWTGfBY1GW5aGWVp/cbcpIc2RSgnZcrxb\n' +
-  '6ef2iTMtUjRd76JlkobTyvgo0GKdLgnr8c711I2YNp+TabKIKZOEvw2X+oGbfxBN\n' +
-  '1WvRB5YJo2rzwZj0fSvN9IwT9TGxSZIo5zcaQuwLEmDZBJShgXN5Ya71Vag1AP2i\n' +
-  'mOwUJRvfTVPWg+wtF2JQwaPpK0+Kb7oCq9tl3PUW40FRgqWV1Tgp6Co/U1W/1BU6\n' +
-  '02Vmic/M/HmRMwWuX1PyVOVr8Mjyj+OMF1JsmdR5eL5Mtg==\n' +
-  '-----END CERTIFICATE-----\n',
+  'scalar.dl.client.tls.ca_root_cert_pem':
+    '-----BEGIN CERTIFICATE-----\n' +
+    'MIIE/jCCAuagAwIBAgIJAJO8tpVEEORLMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV\n' +
+    'BAMMCWxvY2FsaG9zdDAeFw0xOTAzMTMxMDUyMTFaFw0yMDAzMTIxMDUyMTFaMBQx\n' +
+    'EjAQBgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC\n' +
+    'ggIBAKFeFSrXRh5jA+OodMPw0XFO4sd4G9wYERlxgCjDmd9eC+loLpjGwRwwO7os\n' +
+    '/+rhW+Cg/NGhNn64xCmS/JtZf91SBD1QfQ4wk4094sAUIHsztaWtZTATl6aIy0BN\n' +
+    '21A0ueFgVQGehwO1FdRKtS7X+45YV2vMMK/UQ69VSCwY82olBRgWp45TXLUmWVgC\n' +
+    'UAJkE/V2Ch8WLyKpCggtaxYmn8YfzA1X20QDK1b2IW4YPDcPapQLtU6wqIjrXX1E\n' +
+    'w992GgfERm//I14QEyu+qIPafsniDGYxiR6HK8nqeR70QcGHt+Qql24xyjwWHEA/\n' +
+    '43pn3jjrNVRhiVAD8tkVyRmfWjIngksRHPwEh3jG34gshOi9xAaID+mx2AWhThsk\n' +
+    'XbuqSxHckPlvgWHugZmFOwKZAgU5/gpnWR7oHPOSYffhGwmc/+SK/SQ4UDeTFI2c\n' +
+    '40Xw22P8CWbIq4gKi66kSvuFbLSeKQIRMJd50hf7kw3SqnkqEaeRXy5jBovut7CU\n' +
+    'nwcgGPceYmWhKxhkg5urzk+CQZENf+9+pVvArOQemn9bMuaBPwtwXE42+fktQpQ2\n' +
+    'PG3k7ryVL5R0jhuVNXf9ioU2z1ONQ2IdsuFtCKnozfVBAhy9bPfm120rTV/UBOCD\n' +
+    'zcmfRnv081lG9BN/KtZBo7hfFH/ZD2542yVRvibRIIdPWIkTAgMBAAGjUzBRMB0G\n' +
+    'A1UdDgQWBBQ61fQAtAgd7sM/NDtIX4D8GSA/8DAfBgNVHSMEGDAWgBQ61fQAtAgd\n' +
+    '7sM/NDtIX4D8GSA/8DAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IC\n' +
+    'AQCaYh1bxlj9Impoq3rmFHl5/9Fb2o2H2Ne8VjTHb8eSoHuLwXdWzKnw6UhiCaN4\n' +
+    'EZgrsqq1L2Tc8Y+eqT4gz3uDLc5Cj29HHC/suZezIo3lgyZ/A6stYQXE5Gy8e+to\n' +
+    'Qhmf4u8RMZ8zt6i355un6mTJxJq7JxoVqpECf5tg6pMdOUzbcKLTmN6i50jH/PSO\n' +
+    'NQsJhiSJg3caNdWviob+UwEuUineMF/X08dB3gphZ7kmfDeRjmONALMXS1uvPwk2\n' +
+    '3s8S45LmxETx+tcJSvckKRC9JaQf6dgHfKAWHpkIqvLKyqy9Dmvg2RSJi3kI9oaj\n' +
+    'dm64zc6CAsqVaPvoMfWIN7JZq9jvzc8msGiilfhiYoc+M3jvnmM81FuGbAw7Utq4\n' +
+    'uuHtpCcpbxRMChD4WdlrPeBONyBKp+RRWTGfBY1GW5aGWVp/cbcpIc2RSgnZcrxb\n' +
+    '6ef2iTMtUjRd76JlkobTyvgo0GKdLgnr8c711I2YNp+TabKIKZOEvw2X+oGbfxBN\n' +
+    '1WvRB5YJo2rzwZj0fSvN9IwT9TGxSZIo5zcaQuwLEmDZBJShgXN5Ya71Vag1AP2i\n' +
+    'mOwUJRvfTVPWg+wtF2JQwaPpK0+Kb7oCq9tl3PUW40FRgqWV1Tgp6Co/U1W/1BU6\n' +
+    '02Vmic/M/HmRMwWuX1PyVOVr8Mjyj+OMF1JsmdR5eL5Mtg==\n' +
+    '-----END CERTIFICATE-----\n',
 };
 let clientService;
 
@@ -90,8 +91,7 @@ describe('Integration test on ClientService', async () => {
   const contractProperty = {
     properties: 'bar',
   };
-  const mockedByteContract = fs.readFileSync(
-      __dirname + '/StateUpdater.class');
+  const mockedByteContract = fs.readFileSync(__dirname + '/StateUpdater.class');
 
   clientService = new ClientService(properties);
   describe('registerCertificate', () => {
@@ -102,39 +102,43 @@ describe('Integration test on ClientService', async () => {
   });
   describe('registerContract', () => {
     it('should be successful', async () => {
-      const response = await clientService.registerContract(mockedContractId,
+      const response = await clientService.registerContract(
+          mockedContractId,
           mockedContractName,
-          mockedByteContract, contractProperty);
+          mockedByteContract,
+          contractProperty,
+      );
       assert.deepEqual(response, undefined);
     });
   });
   describe('executeContract', () => {
-    it('should work as expected when executing a registered contract',
+    it(
+        'should work as expected when executing a registered contract',
         async () => {
           const response = await clientService.executeContract(
               mockedContractId,
-              mockedContractArgument, {});
+              mockedContractArgument,
+              {},
+          );
 
           const contractResult = response.result;
           assert.equal(contractResult.asset_id, mockedAssetId);
           assert.equal(contractResult.state, mockedState);
-          assert.equal(contractResult.properties,
-              contractProperty.properties);
-        });
-  });
-  describe('validateLedger linearizably', () => {
-    it('should return successfully and the proofs are the same',
-        async () => {
-          await clientService.registerContract(
-              validateLedgerContractId,
-              'com.scalar.dl.client.contract.ValidateLedger',
-              fs.readFileSync(__dirname + '/ValidateLedger.class'),
-              {},
-          );
-
-          const response = await clientService.validateLedger(mockedAssetId);
-          assert.equal(response.getProof(), response.getAuditorProof());
+          assert.equal(contractResult.properties, contractProperty.properties);
         },
     );
+  });
+  describe('validateLedger linearizably', () => {
+    it('should return successfully and the proofs are the same', async () => {
+      await clientService.registerContract(
+          validateLedgerContractId,
+          'com.scalar.dl.client.contract.ValidateLedger',
+          fs.readFileSync(__dirname + '/ValidateLedger.class'),
+          {},
+      );
+
+      const response = await clientService.validateLedger(mockedAssetId);
+      assert.equal(response.getProof(), response.getAuditorProof());
+    });
   });
 });

--- a/test/integration_test_binary_request.js
+++ b/test/integration_test_binary_request.js
@@ -243,13 +243,13 @@ describe('Integration test on ClientServiceWithBinary', async () => {
         'query should return proper object when correct inputs are specified',
         async () => {
           const contractArgumentWithFunction = {
-              asset_id: mockedAssetId,
-              state: Date.now(),
-              _functions_: [mockedFunctionId],
+            asset_id: mockedAssetId,
+            state: Date.now(),
+            _functions_: [mockedFunctionId],
           };
           const mockedFunctionArgument = {
-              asset_id: mockedAssetId,
-              state: mockedState,
+            asset_id: mockedAssetId,
+            state: mockedState,
           };
           const binary =
             await clientService.createSerializedContractExecutionRequest(
@@ -261,8 +261,8 @@ describe('Integration test on ClientServiceWithBinary', async () => {
           const result = response.getResult();
 
           const cassandraClient = new cassandra.Client({
-              contactPoints: ['127.0.0.1:9042'],
-              localDataCenter: 'dc1',
+            contactPoints: ['127.0.0.1:9042'],
+            localDataCenter: 'dc1',
           });
           const cassandraResponse = await cassandraClient.execute(
               `SELECT * FROM foo.bar WHERE column_a='${mockedAssetId}';`,
@@ -279,16 +279,19 @@ describe('Integration test on ClientServiceWithBinary', async () => {
   });
 
   describe('validateLedger', () => {
-    it('should return 200 when correct asset id and age is specified', async () => {
-      const binary =
+    it(
+        'should return 200 when correct asset id and age is specified',
+        async () => {
+          const binary =
         await clientService.createSerializedLedgerValidationRequest(
             mockedAssetId, 0, 1,
         );
-      const response = await clientService.validateLedger(binary);
+          const response = await clientService.validateLedger(binary);
 
-      assert.ok(binary instanceof Uint8Array);
-      assert.equal(response.getCode(), 200);
-    });
+          assert.ok(binary instanceof Uint8Array);
+          assert.equal(response.getCode(), 200);
+        },
+    );
     it('should get error is holder id is incorrect', async () => {
       const anotherProperties = {
         ...properties,

--- a/test/integration_test_file_based_properties.js
+++ b/test/integration_test_file_based_properties.js
@@ -42,7 +42,7 @@ describe('Integration test with File-based Properties', async () => {
     properties: 'bar',
   };
   const mockedByteContract = fs.readFileSync(
-      path.join( __dirname, 'StateUpdater.class'),
+      path.join(__dirname, 'StateUpdater.class'),
   );
   const mockedByteFunction = fs.readFileSync(
       path.join(__dirname, 'TestFunction.class'),


### PR DESCRIPTION
This PR uses [prettier](https://prettier.io/) to reformat the JavaScript files.
Note: They still conform to the ESLint rules.