### PR TITLE
Lock scalardl-samples to 3.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: checkout scalardl-samples repository as it contains the script to spin up scalardl environment and easier for us to maintain the CI
           command: |
             git init
-            git pull https://${GHCR_USERNAME}:${GHCR_PAT}@github.com/scalar-labs/scalardl-samples.git
+            git pull https://${GHCR_USERNAME}:${GHCR_PAT}@github.com/scalar-labs/scalardl-samples.git 3.3
           working_directory: .circleci/
 
       - run:


### PR DESCRIPTION
This PR locks CI's scalardl-samples version to 3.3 in the master branch.
(A new branch 3.3 will be created after release 3.3)