### PR TITLE
Fix a typo `engine` in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
         "mocha": "^9.1.3",
         "mochawesome": "^7.0.1",
         "properties-parser": "^0.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Scalar, Inc.",
   "main": "scalardl-node-client-sdk.js",
   "license": "AGPL-3.0-or-later",
-  "engine": {
+  "engines": {
     "node": ">=16.0.0"
   },
   "repository": {


### PR DESCRIPTION
This PR fixes a typo in package.json.

It's `engines`, not `engine`.
Reference: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines

This is reminded in https://github.com/scalar-labs/scalar-admin/pull/17#discussion_r879034802