### PR TITLE
To support Node.js 14 ~ 16 with NPM > 7

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 14.x
           - 16.x
 
     steps:
@@ -51,6 +52,9 @@ jobs:
         docker-compose -f docker-compose.yml -f expose-cassandra-port.yml up -d scalar-ledger ledger-envoy
         sleep 5
 
+    - name: Update NPM to the latest stable version
+      run: npm install -g npm@latest
+
     - name: NPM Install
       run: npm install
 
@@ -63,6 +67,7 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 14.x
           - 16.x
 
     steps:
@@ -105,6 +110,9 @@ jobs:
         docker restart scalardl-samples-scalar-ledger-1 # just in case
         docker restart scalardl-samples-scalar-auditor-1 # just in case
         sleep 5
+
+    - name: Update NPM to the latest stable version
+      run: npm install -g npm@latest
 
     - name: NPM Install
       run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "properties-parser": "^0.3.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=14 <17",
+        "npm": ">=7"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "scalardl-node-client-sdk.js",
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=14 <17",
+    "npm": ">=7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR revises package.json to declare that this package should be run on
- Node.js version
    - 14 (maintenance LTS until Apr 2023)
    - 15 (EOL)
    - 16 (active LTS until Oct 2022, maintenance LTS until Apr 2024)
- NPM version at least > 7 (to run package-lock.json version 2)

It also creates another GitHub Actions to run end-to-end testing on Node.js version 14.