### PR TITLE
Reject the reuqest of ledger validation when auditor is enabled

### DIFF
--- a/scalardl-node-client-sdk.js
+++ b/scalardl-node-client-sdk.js
@@ -223,6 +223,16 @@ class ClientServiceWithBinary extends ClientServiceBase {
    * @return {Promise<!proto.google.protobuf.LedgerValidationResponse>}
    */
   async validateLedger(serializedBinary) {
+    const properties = new ClientProperties(this.properties, [], []);
+    if (properties.getAuditorEnabled()) {
+      throw new Error(
+          'validateLedger with Auditor ' +
+          'is not supported in the intermediary mode. ' +
+          'Please execute ValidateLedger contract ' +
+          'simply for validating assets.',
+      );
+    }
+
     const request =
       this.ledgerClient.validateLedger.requestDeserialize(serializedBinary);
 

--- a/test/integration_test_binary_request.js
+++ b/test/integration_test_binary_request.js
@@ -318,4 +318,39 @@ describe('Integration test on ClientServiceWithBinary', async () => {
       );
     });
   });
+
+  describe('validateLedger in the auditor mode', () => {
+    it('should return error when the auditor mode is enabled', async () => {
+      const anotherProperties = {
+        ...properties,
+        ...{
+          'scalar.dl.client.auditor.enabled': true,
+        },
+      };
+      const anotherClientService = new ClientServiceWithBinary(
+          anotherProperties,
+      );
+
+      const binary =
+        await anotherClientService.createSerializedLedgerValidationRequest(
+            mockedAssetId,
+            0,
+            1,
+        );
+
+      await assert.rejects(
+          anotherClientService.validateLedger(binary),
+          (err) => {
+            assert.equal(
+                err.message,
+                'validateLedger with Auditor ' +
+              'is not supported in the intermediary mode. ' +
+              'Please execute ValidateLedger contract ' +
+              'simply for validating assets.',
+            );
+            return true;
+          },
+      );
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a conditional statment in `ClientBinaryService.validateLedger` to reject the requests when the auditor mode is enabled.

This is report by Jun in https://github.com/scalar-labs/scalardl-javascript-sdk-base/pull/85#pullrequestreview-1105136846